### PR TITLE
Idea to use sealed classes on ViewHolders

### DIFF
--- a/Umweltzone/src/main/java/de/avpptr/umweltzone/zones/ZonesAdapter.kt
+++ b/Umweltzone/src/main/java/de/avpptr/umweltzone/zones/ZonesAdapter.kt
@@ -32,10 +32,11 @@ class ZonesAdapter(
         private val onItemClick: (view: View) -> Unit,
         private val onItemViewInflationError: (viewType: Int) -> Unit
 
-) : RecyclerView.Adapter<ZoneViewHolder>() {
+) : RecyclerView.Adapter<ZoneViewHolder<ZoneViewModel>>() {
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ZoneViewHolder {
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ZoneViewHolder<ZoneViewModel> {
         val inflater = LayoutInflater.from(parent.context)
+        @Suppress("UNCHECKED_CAST")
         return when (viewType) {
             ChildZonesCount.ONE.value -> {
                 val itemView = inflater.inflate(OneZoneViewHolder.layout, parent, false)
@@ -49,16 +50,12 @@ class ZonesAdapter(
                 onItemViewInflationError.invoke(viewType)
                 error("Unknown view type: $viewType")
             }
-        }
+        } as ZoneViewHolder<ZoneViewModel>
     }
 
-    override fun onBindViewHolder(viewHolder: ZoneViewHolder, position: Int) {
+    override fun onBindViewHolder(viewHolder: ZoneViewHolder<ZoneViewModel>, position: Int) {
         val viewModel = zones[position]
-        when (viewHolder) {
-            is OneZoneViewHolder -> viewHolder.bind(viewModel as ZoneViewModel.OneZoneViewModel)
-            is TwoZonesViewHolder -> viewHolder.bind(viewModel as ZoneViewModel.TwoZonesViewModel)
-            else -> error("Unknown view holder: $viewHolder")
-        }
+        viewHolder.bind(viewModel)
     }
 
     override fun getItemCount(): Int =

--- a/Umweltzone/src/main/java/de/avpptr/umweltzone/zones/viewholders/OneZoneViewHolder.kt
+++ b/Umweltzone/src/main/java/de/avpptr/umweltzone/zones/viewholders/OneZoneViewHolder.kt
@@ -30,7 +30,7 @@ class OneZoneViewHolder(
         val view: View,
         private val onItemClick: (view: View) -> Unit
 
-) : ZoneViewHolder(view) {
+) : ZoneViewHolder<ZoneViewModel.OneZoneViewModel>(view) {
 
     private val zoneShapeView: GradientDrawable
 
@@ -39,7 +39,7 @@ class OneZoneViewHolder(
         zoneShapeView = badgeBackground.findDrawableByLayerId(R.id.zone_shape) as GradientDrawable
     }
 
-    fun bind(viewModel: ZoneViewModel.OneZoneViewModel) = with(view) {
+    override fun bind(viewModel: ZoneViewModel.OneZoneViewModel) = with(view) {
         tag = viewModel
         setOnClickListener(onItemClick)
         zoneOneZoneNameView.text = viewModel.name

--- a/Umweltzone/src/main/java/de/avpptr/umweltzone/zones/viewholders/TwoZonesViewHolder.kt
+++ b/Umweltzone/src/main/java/de/avpptr/umweltzone/zones/viewholders/TwoZonesViewHolder.kt
@@ -30,7 +30,7 @@ class TwoZonesViewHolder(
         val view: View,
         private val onItemClick: (view: View) -> Unit
 
-) : ZoneViewHolder(view) {
+) : ZoneViewHolder<ZoneViewModel.TwoZonesViewModel>(view) {
 
     private val zoneShape1View: GradientDrawable
     private val zoneShape2View: GradientDrawable
@@ -42,7 +42,7 @@ class TwoZonesViewHolder(
         zoneShape2View = badge2Background.findDrawableByLayerId(R.id.zone_shape) as GradientDrawable
     }
 
-    fun bind(viewModel: ZoneViewModel.TwoZonesViewModel) = with(view) {
+    override fun bind(viewModel: ZoneViewModel.TwoZonesViewModel) = with(view) {
         tag = viewModel
         setOnClickListener(onItemClick)
         zoneTwoZonesNameView.text = viewModel.name

--- a/Umweltzone/src/main/java/de/avpptr/umweltzone/zones/viewholders/ZoneViewHolder.kt
+++ b/Umweltzone/src/main/java/de/avpptr/umweltzone/zones/viewholders/ZoneViewHolder.kt
@@ -24,8 +24,11 @@ import android.support.v7.widget.RecyclerView
 import android.view.View
 import android.widget.TextView
 import de.avpptr.umweltzone.zones.viewmodels.BadgeViewModel
+import de.avpptr.umweltzone.zones.viewmodels.ZoneViewModel
 
-abstract class ZoneViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+abstract class ZoneViewHolder<in T: ZoneViewModel>(view: View) : RecyclerView.ViewHolder(view) {
+
+    abstract fun bind(viewModel: T)
 
     protected fun TextView.setBadge(zoneShapeView: GradientDrawable, viewModel: BadgeViewModel) {
         this.text = viewModel.text


### PR DESCRIPTION
Following our Slack conversation. I took a look at the code, and I did a couple of changes.

This is what I usually do when using sealed classes together with ViewHolders on RecyclerView Adapters. I am not sure if it is the best solution.

The advantage is getting rid of the `when` case in `onBindViewHolder`.

The disadvantage is the `UNCHECKED_CAST` in `onCreateViewHolder`. It is what annoys me most. Maybe this can be improved but I could not figure it out.

But what I like most is having an abstract `bind` method that all future ViewHolders have to implement, including adding a new sealed class child.

Let me know what you think!