### PR TITLE
Completely restore the map view on rotation as chosen by the user.

### DIFF
--- a/Umweltzone/src/main/java/de/avpptr/umweltzone/contract/Preferences.java
+++ b/Umweltzone/src/main/java/de/avpptr/umweltzone/contract/Preferences.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2018  Tobias Preuss
+ *  Copyright (C) 2019  Tobias Preuss
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -21,17 +21,14 @@ import de.avpptr.umweltzone.BuildConfig;
 
 public interface Preferences {
 
-    String KEY_LAST_KNOWN_LOCATION_CENTER =
-            BuildConfig.APPLICATION_ID + ".LAST_KNOWN_LOCATION_CENTER";
+    String KEY_CAMERA_POSITION =
+            BuildConfig.APPLICATION_ID + ".CAMERA_POSITION";
 
     String KEY_LAST_KNOWN_LOCATION_BOUNDING_BOX =
             BuildConfig.APPLICATION_ID + ".LAST_KNOWN_LOCATION_BOUNDING_BOX";
 
     String KEY_CITY_NAME =
             BuildConfig.APPLICATION_ID + ".CITY_NAME";
-
-    String KEY_ZOOM_LEVEL =
-            BuildConfig.APPLICATION_ID + ".ZOOM_LEVEL";
 
     String KEY_CITY_NAME_FRANKFURT_IN_PREFERENCES_FIXED =
             BuildConfig.APPLICATION_ID + ".CITY_NAME_FRANKFURT_IN_PREFERENCES_FIXED";

--- a/Umweltzone/src/main/java/de/avpptr/umweltzone/map/MapFragment.java
+++ b/Umweltzone/src/main/java/de/avpptr/umweltzone/map/MapFragment.java
@@ -42,6 +42,7 @@ import com.google.android.gms.maps.CameraUpdateFactory;
 import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.MapView;
 import com.google.android.gms.maps.OnMapReadyCallback;
+import com.google.android.gms.maps.model.CameraPosition;
 import com.google.android.gms.maps.model.LatLngBounds;
 
 import org.ligi.tracedroid.logging.Log;
@@ -145,8 +146,8 @@ public class MapFragment extends BaseFragment implements OnMapReadyCallback {
                     }
 
                     @Override
-                    public void onZoomToLocation(@NonNull GeoPoint location, float zoomLevel) {
-                        zoomToLocation(location, zoomLevel);
+                    public void onZoomToLocation(@NonNull CameraPosition cameraPosition) {
+                        zoomToLocation(cameraPosition);
                     }
 
                 });
@@ -229,12 +230,8 @@ public class MapFragment extends BaseFragment implements OnMapReadyCallback {
         }
     }
 
-    private void zoomToLocation(@NonNull GeoPoint location, float zoomLevel) {
-        if (location.isValid() && zoomLevel > 0) {
-            CameraUpdate cameraUpdate = CameraUpdateFactory.newLatLngZoom(
-                    location.toLatLng(), zoomLevel);
-            mMap.moveCamera(cameraUpdate);
-        }
+    private void zoomToLocation(@NonNull CameraPosition cameraPosition) {
+        mMap.moveCamera(CameraUpdateFactory.newCameraPosition(cameraPosition));
     }
 
     private void setUpMapIfNeeded() {
@@ -355,10 +352,7 @@ public class MapFragment extends BaseFragment implements OnMapReadyCallback {
 
     private void storeLastMapState() {
         if (mMap != null) {
-            GeoPoint mapCenter = new GeoPoint(mMap.getCameraPosition().target);
-            mPreferencesHelper.storeLastKnownLocationAsGeoPoint(mapCenter);
-            float zoomLevel = mMap.getCameraPosition().zoom;
-            mPreferencesHelper.storeZoomLevel(zoomLevel);
+            mPreferencesHelper.storeCameraPosition(mMap.getCameraPosition());
         }
     }
 

--- a/Umweltzone/src/main/java/de/avpptr/umweltzone/map/MapReadyDelegate.kt
+++ b/Umweltzone/src/main/java/de/avpptr/umweltzone/map/MapReadyDelegate.kt
@@ -17,10 +17,11 @@
 
 package de.avpptr.umweltzone.map
 
+import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLngBounds
+import de.avpptr.umweltzone.models.extensions.isValid
 import de.avpptr.umweltzone.models.LowEmissionZone
 import de.avpptr.umweltzone.prefs.PreferencesHelper
-import de.avpptr.umweltzone.utils.GeoPoint
 
 internal class MapReadyDelegate(
 
@@ -48,10 +49,9 @@ internal class MapReadyDelegate(
             }
             setCenterZoneRequested.invoke(false)
         } else {
-            val lastKnownPosition = preferencesHelper.restoreLastKnownLocationAsGeoPoint()
-            if (lastKnownPosition.isValid) {
-                val zoomLevel = preferencesHelper.restoreZoomLevel()
-                listener.onZoomToLocation(lastKnownPosition, zoomLevel)
+            val lastKnownCameraPosition = preferencesHelper.restoreCameraPosition()
+            if (lastKnownCameraPosition.isValid()) {
+                listener.onZoomToLocation(lastKnownCameraPosition)
             } else {
                 // Select default city at first application start
                 getDefaultLowEmissionZone.invoke()?.let {
@@ -81,7 +81,7 @@ internal class MapReadyDelegate(
 
         fun onZoomToBounds(latLngBounds: LatLngBounds)
 
-        fun onZoomToLocation(location: GeoPoint, zoomLevel: Float)
+        fun onZoomToLocation(cameraPosition: CameraPosition)
 
     }
 

--- a/Umweltzone/src/main/java/de/avpptr/umweltzone/models/extensions/CameraPositionExtensions.kt
+++ b/Umweltzone/src/main/java/de/avpptr/umweltzone/models/extensions/CameraPositionExtensions.kt
@@ -1,0 +1,24 @@
+@file:JvmName("CameraPositionExtensions")
+
+/*
+ *  Copyright (C) 2019  Tobias Preuss
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package de.avpptr.umweltzone.models.extensions
+
+import com.google.android.gms.maps.model.CameraPosition
+
+fun CameraPosition.isValid() = target.isValid() && zoom > 0

--- a/Umweltzone/src/main/java/de/avpptr/umweltzone/models/extensions/LatLngExtensions.kt
+++ b/Umweltzone/src/main/java/de/avpptr/umweltzone/models/extensions/LatLngExtensions.kt
@@ -1,0 +1,24 @@
+@file:JvmName("LatLngExtensions")
+
+/*
+ *  Copyright (C) 2019  Tobias Preuss
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package de.avpptr.umweltzone.models.extensions
+
+import com.google.android.gms.maps.model.LatLng
+
+fun LatLng.isValid() = latitude.isValidLatitude && longitude.isValidLongitude

--- a/Umweltzone/src/main/java/de/avpptr/umweltzone/models/extensions/LatitudeExtensions.kt
+++ b/Umweltzone/src/main/java/de/avpptr/umweltzone/models/extensions/LatitudeExtensions.kt
@@ -1,0 +1,30 @@
+@file:JvmName("LatitudeExtensions")
+
+/*
+ *  Copyright (C) 2019  Tobias Preuss
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package de.avpptr.umweltzone.models.extensions
+
+const val MIN_LATITUDE = -90.0
+const val MAX_LATITUDE = 90.0
+
+/**
+ * Latitude, in degrees. This value is in the range [-90, 90].
+ * See: https://developers.google.com/android/reference/com/google/android/gms/maps/model/LatLng
+ */
+val Double.isValidLatitude
+    get() = (MIN_LATITUDE..MAX_LATITUDE).contains(this)

--- a/Umweltzone/src/main/java/de/avpptr/umweltzone/models/extensions/LongitudeExtensions.kt
+++ b/Umweltzone/src/main/java/de/avpptr/umweltzone/models/extensions/LongitudeExtensions.kt
@@ -1,0 +1,30 @@
+@file:JvmName("LongitudeExtensions")
+
+/*
+ *  Copyright (C) 2019  Tobias Preuss
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package de.avpptr.umweltzone.models.extensions
+
+const val MIN_LONGITUDE = -180.0
+const val MAX_LONGITUDE = 180.0
+
+/**
+ * Longitude, in degrees. This value is in the range [-180, 180).
+ * See: https://developers.google.com/android/reference/com/google/android/gms/maps/model/LatLng
+ */
+val Double.isValidLongitude
+    get() = MIN_LONGITUDE <= this && this < MAX_LONGITUDE

--- a/Umweltzone/src/main/java/de/avpptr/umweltzone/prefs/CameraPositionPreference.kt
+++ b/Umweltzone/src/main/java/de/avpptr/umweltzone/prefs/CameraPositionPreference.kt
@@ -1,0 +1,63 @@
+/*
+ *  Copyright (C) 2019  Tobias Preuss
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package de.avpptr.umweltzone.prefs
+
+import android.content.SharedPreferences
+
+import com.google.android.gms.maps.model.CameraPosition
+import com.google.android.gms.maps.model.LatLng
+
+import de.avpptr.umweltzone.utils.GeoPoint
+import info.metadude.android.typedpreferences.FloatPreference
+
+class CameraPositionPreference(
+
+        sharedPreferences: SharedPreferences,
+        key: String
+
+) {
+
+    private val targetPreference = GeoPointPreference(sharedPreferences, "$key.TARGET")
+    private val zoomPreference = FloatPreference(sharedPreferences, "$key.ZOOM")
+    private val tiltPreference = FloatPreference(sharedPreferences, "$key.TILT")
+    private val bearingPreference = FloatPreference(sharedPreferences, "$key.BEARING")
+
+    fun get(): CameraPosition {
+        val geoPoint = targetPreference.get()
+        val target = LatLng(geoPoint.latitude, geoPoint.longitude)
+        val zoom = zoomPreference.get()
+        val tilt = tiltPreference.get()
+        val bearing = bearingPreference.get()
+        return CameraPosition(target, zoom, tilt, bearing)
+    }
+
+    fun set(cameraPosition: CameraPosition) {
+        targetPreference.set(GeoPoint(cameraPosition.target))
+        zoomPreference.set(cameraPosition.zoom)
+        tiltPreference.set(cameraPosition.tilt)
+        bearingPreference.set(cameraPosition.bearing)
+    }
+
+    fun delete() {
+        targetPreference.delete()
+        zoomPreference.delete()
+        tiltPreference.delete()
+        bearingPreference.delete()
+    }
+
+}

--- a/Umweltzone/src/main/java/de/avpptr/umweltzone/prefs/PreferencesHelper.java
+++ b/Umweltzone/src/main/java/de/avpptr/umweltzone/prefs/PreferencesHelper.java
@@ -21,24 +21,22 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.support.annotation.NonNull;
 
+import com.google.android.gms.maps.model.CameraPosition;
+
 import de.avpptr.umweltzone.R;
 import de.avpptr.umweltzone.contract.Preferences;
 import de.avpptr.umweltzone.models.LowEmissionZone;
 import de.avpptr.umweltzone.utils.BoundingBox;
-import de.avpptr.umweltzone.utils.GeoPoint;
 import info.metadude.android.typedpreferences.BooleanPreference;
-import info.metadude.android.typedpreferences.FloatPreference;
 import info.metadude.android.typedpreferences.StringPreference;
 
 public class PreferencesHelper {
 
     private final StringPreference mCityNamePreference;
 
-    private final GeoPointPreference mLastKnownLocationCenterPreference;
+    private final CameraPositionPreference mCameraPositionPreference;
 
     private final BoundingBoxPreference mLastKnownLocationBoundingBoxPreference;
-
-    private final FloatPreference mZoomLevelPreference;
 
     private final BooleanPreference mZoneIsDrawablePreference;
 
@@ -54,12 +52,10 @@ public class PreferencesHelper {
     public PreferencesHelper(@NonNull SharedPreferences sharedPreferences, @NonNull Context context) {
         mCityNamePreference = new StringPreference(
                 sharedPreferences, Preferences.KEY_CITY_NAME);
-        mLastKnownLocationCenterPreference = new GeoPointPreference(
-                sharedPreferences, Preferences.KEY_LAST_KNOWN_LOCATION_CENTER);
+        mCameraPositionPreference = new CameraPositionPreference(
+                sharedPreferences, Preferences.KEY_CAMERA_POSITION);
         mLastKnownLocationBoundingBoxPreference = new BoundingBoxPreference(
                 sharedPreferences, Preferences.KEY_LAST_KNOWN_LOCATION_BOUNDING_BOX);
-        mZoomLevelPreference = new FloatPreference(
-                sharedPreferences, Preferences.KEY_ZOOM_LEVEL);
         mZoneIsDrawablePreference = new BooleanPreference(
                 sharedPreferences, Preferences.KEY_ZONE_IS_DRAWABLE);
         mCityNameFrankfurtInPreferencesFixedPreference = new BooleanPreference(
@@ -84,6 +80,20 @@ public class PreferencesHelper {
         storeZoneIsDrawable(zone.containsGeometryInformation());
     }
 
+    // CameraPosition
+
+    public void storeCameraPosition(@NonNull final CameraPosition cameraPosition) {
+        mCameraPositionPreference.set(cameraPosition);
+    }
+
+    public CameraPosition restoreCameraPosition() {
+        return mCameraPositionPreference.get();
+    }
+
+    private void deleteCameraPosition() {
+        mCameraPositionPreference.delete();
+    }
+
     // Last known location / city name
 
     public void storeLastKnownLocationAsString(final String cityName) {
@@ -102,20 +112,6 @@ public class PreferencesHelper {
         mCityNamePreference.delete();
     }
 
-    // Last known location / center
-
-    public void storeLastKnownLocationAsGeoPoint(final GeoPoint center) {
-        mLastKnownLocationCenterPreference.set(center);
-    }
-
-    public GeoPoint restoreLastKnownLocationAsGeoPoint() {
-        return mLastKnownLocationCenterPreference.get();
-    }
-
-    private void deleteLastKnownLocationAsGeoPoint() {
-        mLastKnownLocationCenterPreference.delete();
-    }
-
     // Last known location / bounding box
 
     private void storeLastKnownLocationAsBoundingBox(final BoundingBox boundingBox) {
@@ -128,20 +124,6 @@ public class PreferencesHelper {
 
     private void deleteLastKnownLocationAsBoundingBox() {
         mLastKnownLocationBoundingBoxPreference.delete();
-    }
-
-    // Zoom level
-
-    public void storeZoomLevel(float zoomLevel) {
-        mZoomLevelPreference.set(zoomLevel);
-    }
-
-    public float restoreZoomLevel() {
-        return mZoomLevelPreference.get();
-    }
-
-    private void deleteZoomLevel() {
-        mZoomLevelPreference.delete();
     }
 
     // Zone is drawable
@@ -208,8 +190,7 @@ public class PreferencesHelper {
     public void deleteLastKnownLocation() {
         deleteLastKnownLocationAsString();
         deleteLastKnownLocationAsBoundingBox();
-        deleteLastKnownLocationAsGeoPoint();
-        deleteZoomLevel();
+        deleteCameraPosition();
         deleteZoneIsDrawable();
     }
 

--- a/Umweltzone/src/main/java/de/avpptr/umweltzone/utils/GeoPoint.java
+++ b/Umweltzone/src/main/java/de/avpptr/umweltzone/utils/GeoPoint.java
@@ -27,16 +27,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
+import static de.avpptr.umweltzone.models.extensions.LatitudeExtensions.MIN_LATITUDE;
+import static de.avpptr.umweltzone.models.extensions.LatitudeExtensions.isValidLatitude;
+import static de.avpptr.umweltzone.models.extensions.LongitudeExtensions.MIN_LONGITUDE;
+import static de.avpptr.umweltzone.models.extensions.LongitudeExtensions.isValidLongitude;
+
 @Parcel
 public final class GeoPoint {
-
-    private static final double MAX_LATITUDE = 90.0;
-
-    private static final double MIN_LATITUDE = -90.0;
-
-    private static final double MAX_LONGITUDE = 180.0;
-
-    private static final double MIN_LONGITUDE = -180.0;
 
     private static final double INVALID_LATITUDE = MIN_LATITUDE - 1;
 
@@ -91,8 +88,7 @@ public final class GeoPoint {
     }
 
     public boolean isValid() {
-        return (mLatitude > MIN_LATITUDE && mLatitude <= MAX_LATITUDE
-                && mLongitude > MIN_LONGITUDE && mLongitude <= MAX_LONGITUDE);
+        return isValidLatitude(mLatitude) && isValidLongitude(mLongitude);
     }
 
     public LatLng toLatLng() {

--- a/Umweltzone/src/test/java/de/avpptr/umweltzone/models/extensions/CameraPositionExtensionsTest.kt
+++ b/Umweltzone/src/test/java/de/avpptr/umweltzone/models/extensions/CameraPositionExtensionsTest.kt
@@ -1,0 +1,23 @@
+package de.avpptr.umweltzone.models.extensions
+
+import com.google.android.gms.maps.model.CameraPosition
+import com.google.android.gms.maps.model.LatLng
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class CameraPositionExtensionsTest {
+
+    // Testing LatLon with invalid latitude or longitude is a waste of time
+    // because the LatLong normalized invalid input values at construction time.
+
+    @Test
+    fun isValidWithValidZoom() {
+        assertThat(CameraPosition(LatLng(-90.0, -180.0), 0.1f, 0f, 0f).isValid()).isTrue()
+    }
+
+    @Test
+    fun isValidWithInvalidZoom() {
+        assertThat(CameraPosition(LatLng(-90.0, -180.0), 0.0f, 0f, 0f).isValid()).isFalse()
+    }
+
+}

--- a/Umweltzone/src/test/java/de/avpptr/umweltzone/models/extensions/LatitudeExtensionsTest.kt
+++ b/Umweltzone/src/test/java/de/avpptr/umweltzone/models/extensions/LatitudeExtensionsTest.kt
@@ -1,0 +1,36 @@
+package de.avpptr.umweltzone.models.extensions
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+
+@RunWith(Parameterized::class)
+class LatitudeExtensionsTest(
+
+        private val latitude: Double,
+        private val isValid: Boolean
+
+) {
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters(name = "{index}: {0}.isValidLatitude => {1}")
+        fun data(): Collection<Array<Any>> {
+            return listOf(
+                    arrayOf(-90.1, false),
+                    arrayOf(-90.0, true),
+                    arrayOf(0, true),
+                    arrayOf(90.0, true),
+                    arrayOf(90.1, false)
+            )
+        }
+    }
+
+    @Test
+    fun isValid() {
+        assertThat(latitude.isValidLatitude).isEqualTo(isValid)
+    }
+
+}

--- a/Umweltzone/src/test/java/de/avpptr/umweltzone/models/extensions/LongitudeExtensionsTest.kt
+++ b/Umweltzone/src/test/java/de/avpptr/umweltzone/models/extensions/LongitudeExtensionsTest.kt
@@ -1,0 +1,36 @@
+package de.avpptr.umweltzone.models.extensions
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+
+@RunWith(Parameterized::class)
+class LongitudeExtensionsTest(
+
+        private val longitude: Double,
+        private val isValid: Boolean
+
+) {
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters(name = "{index}: {0}.isValidLongitude => {1}")
+        fun data(): Collection<Array<Any>> {
+            return listOf(
+                    arrayOf(-180.1, false),
+                    arrayOf(-180.0, true),
+                    arrayOf(0, true),
+                    arrayOf(180.0, false),
+                    arrayOf(180.1, false)
+            )
+        }
+    }
+
+    @Test
+    fun isValid() {
+        assertThat(longitude.isValidLongitude).isEqualTo(isValid)
+    }
+
+}


### PR DESCRIPTION
+ Store and restore "tilt" angle and "bearing" of the map camera position.
  Before only "target" location and "zoom" level have been kept.

  - Map before rotation
    ![Map before rotation](https://user-images.githubusercontent.com/144518/55276093-8bf10280-52ef-11e9-9b29-6067eb39feec.png)
  - Map after rotation
    ![Map after rotation](https://user-images.githubusercontent.com/144518/55276097-8e535c80-52ef-11e9-915d-ef9f254ad28e.png)

- Successfully tested on Nexus 9, Android 7.1.1.

Resolves #20.