### PR TITLE
Add Diesel prohibition zone for Munich (matches low emission zone).

### DIFF
--- a/Umweltzone/src/main/java/de/avpptr/umweltzone/models/extensions/ChildZoneExtensions.kt
+++ b/Umweltzone/src/main/java/de/avpptr/umweltzone/models/extensions/ChildZoneExtensions.kt
@@ -30,6 +30,8 @@ val ChildZone.roadSignType: RoadSign.Type
         zoneNumber == LowEmissionZoneNumbers.YELLOW -> RoadSign.Type.EnvironmentalBadge.YellowGreen
         zoneNumber == LowEmissionZoneNumbers.GREEN -> RoadSign.Type.EnvironmentalBadge.Green
 
+        zoneNumber == LowEmissionZoneNumbers.LIGHT_BLUE && fileName == "lez_munich" ->
+            RoadSign.Type.DieselProhibition.FreeAsOfEuro5VExceptDeliveryVehiclesStuttgart // reuse Stuttgart
         zoneNumber == LowEmissionZoneNumbers.LIGHT_BLUE && fileName == "lez_stuttgart" ->
             RoadSign.Type.DieselProhibition.FreeAsOfEuro5VExceptDeliveryVehiclesStuttgart
         zoneNumber == LowEmissionZoneNumbers.DARK_BLUE && fileName == "dpz_hamburg_max_brauer_allee" ->

--- a/Umweltzone/src/main/res/raw/zones_de.json
+++ b/Umweltzone/src/main/res/raw/zones_de.json
@@ -1034,6 +1034,17 @@
             "geometrySource" : "Stadt München",
             "geometryUpdatedAt" : "2013-10-14",
             "listOfCities" : []
+        }, {
+            "type" : "diesel-prohibition-zone",
+            "fileName" : "lez_munich",
+            "displayName" : "",
+            "zoneNumber" : "5",
+            "zoneNumberForResidentsSince" : "2023-02-01",
+            "zoneNumberForNonResidentsSince" : "2023-02-01",
+            "prohibitedVehicles" : [],
+            "isCongruentWithLowEmissionZone" : true,
+            "geometrySource" : "Stadt Stuttgart",
+            "geometryUpdatedAt" : "2013-10-14"
         }],
         "contactEmails" : null,
         "urlBadgeOnline" : "",


### PR DESCRIPTION
# Description
+ Munich applies a Diesel prohibition zone as of 01.02.2023.
+ https://stadt.muenchen.de/infos/umweltzone-muenchen.html

# Successfully tested `debug` build on
- Google Pixel 6 device, Android 13 (API 33)